### PR TITLE
Mention the SageMaker lab must use us-east-1

### DIFF
--- a/SageMaker lab/ReadMe.md
+++ b/SageMaker lab/ReadMe.md
@@ -10,6 +10,8 @@ This will download the repo as a zip file. Extract the zip file.
 
 ### Step 1- Create notebook instance
 
+NOTE: You need to build your SageMaker resources in the **US East Virginia** region in order to access the necessary S3 buckets.
+
 Go to SageMaker console: https://console.aws.amazon.com/sagemaker
 
 Click on Create Notebook instance


### PR DESCRIPTION
When building outside of us-east-1, the 'sagemaker-obj-det-demo' bucket is not accessible and the notebook fails with permissions errors.